### PR TITLE
Add WB350F to known cameras list

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ If you'd like to donate to the development of PC AutoBackup use the following li
   * DV300F
   * NX1000
   * WB150F
+  * WB350F
   * Does it work with your camera? Send me a pull request editing this README.
 
 ## **Tested on the following OS:** ##

--- a/common.py
+++ b/common.py
@@ -19,6 +19,8 @@ CAMERA_CONFIG = {
                                               'SAMSUNGAutoBackupDESC.ini')},
   'SAMSUNG WB150': {'desc_file': os.path.join('DLNA_WEB_ROOT',
                                               'SAMSUNGAUTOBACKUPDESC.INI')},
+  'SAMSUNG WB350F': {'desc_file': os.path.join('DLNA_WEB_ROOT',
+                                              'SAMSUNGAutoBackupDESC.ini')},
   'SAMSUNG NX1000': {'desc_file': os.path.join('dlna_web_root',
                                                'SAMSUNGAutoBackupDESC.ini')}}
 CONFIG_FILE = os.path.expanduser("~/.pc_autobackup.cfg")


### PR DESCRIPTION
pc_autobackup.py works with the Samsung WB350F camera, so the camera is added to the
README.md file and the CAMERA_CONFIG dict in common.py