### PR TITLE
Determine host ip for mediaserver and SSDP server dynamically

### DIFF
--- a/common.py
+++ b/common.py
@@ -93,13 +93,6 @@ def LoadOrCreateConfig():
                os.path.expanduser('~/PCAutoBackup'))
   if not config.has_option('AUTOBACKUP', 'create_date_subdir'):
     config.set('AUTOBACKUP', 'create_date_subdir', '1')
-  if not config.has_option('AUTOBACKUP', 'default_interface'):
-    try:
-      config.set('AUTOBACKUP', 'default_interface',
-                 socket.gethostbyname(socket.gethostname()))
-    except socket.error:
-      logger.error('Unable to determine IP address. Please set manually!')
-      config.set('AUTOBACKUP', 'default_interface', '127.0.0.1')
   if not config.has_option('AUTOBACKUP', 'server_name'):
     config.set('AUTOBACKUP', 'server_name', '[PC]AutoBackup')
   if not config.has_option('AUTOBACKUP', 'uuid'):

--- a/mediaserver.py
+++ b/mediaserver.py
@@ -265,7 +265,7 @@ class MediaServer(Resource):
                          obj_size)
 
         response_dict = {
-            'interface': self.config.get('AUTOBACKUP', 'default_interface'),
+            'interface': request.getHost().host,
             'obj_class': obj_class,
             'obj_id': obj_id,
             'obj_size': obj_size,

--- a/mediaserver.py
+++ b/mediaserver.py
@@ -165,6 +165,7 @@ class MediaServer(Resource):
                         request.getClientIP(), request.args)
       self.logger.debug('Request headers for %s from %s: %s', request.path,
                         request.getClientIP(), request.args)
+      self.logger.debug('Request came on interface %s', request.getHost().host)
 
     if request.path == '/DMS/SamsungDmsDesc.xml':
       self.logger.info('New connection from %s (%s)', request.getClientIP(),
@@ -196,6 +197,7 @@ class MediaServer(Resource):
                       request.getClientIP(), request.args)
     self.logger.debug('Request headers for %s from %s: %s', request.path,
                       request.getClientIP(), request.args)
+    self.logger.debug('Request came on interface %s', request.getHost().host)
 
     if request.path == '/cd/content':
       response = self.ReceiveUpload(request)

--- a/pc_autobackup.py
+++ b/pc_autobackup.py
@@ -246,8 +246,13 @@ def main():
     UpdateCameraConfig(options.update_camera_config)
     sys.exit(0)
 
-  logger.info('PCAutoBackup started on %s', config.get('AUTOBACKUP',
-                                                       'default_interface'))
+  if config.has_option('AUTOBACKUP', 'default_interface'):
+    interface = config.get('AUTOBACKUP', 'default_interface')
+    logger.info('PCAutoBackup started on %s', interface)
+  else:
+    interface = ""
+    logger.info('PCAutoBackup started on all interfaces')
+
   logger.info('Server name: %s', config.get('AUTOBACKUP', 'server_name'))
 
   if options.debug:
@@ -258,7 +263,7 @@ def main():
 
   resource = mediaserver.MediaServer()
   factory = Site(resource)
-  reactor.listenTCP(52235, factory)
+  reactor.listenTCP(52235, factory, interface=interface)
   logger.info('MediaServer started')
 
   reactor.run()

--- a/ssdp.py
+++ b/ssdp.py
@@ -8,6 +8,7 @@ __author__ = 'jeff@rebeiro.net (Jeff Rebeiro)'
 import ConfigParser
 import logging
 import re
+import socket
 
 from twisted.internet import reactor
 from twisted.internet.protocol import DatagramProtocol
@@ -113,9 +114,9 @@ class SSDPServer(DatagramProtocol):
     Args:
       address: A tuple of destination IP (string) and port (int)
     """
+    host_ip,host_port = self.GetHostAddress(address)
     response = self.GenerateSSDPResponse('m-search',
-                                         self.config.get('AUTOBACKUP',
-                                                         'default_interface'),
+                                         host_ip,
                                          self.config.get('AUTOBACKUP', 'uuid'))
 
     address_info = ':'.join([str(x) for x in address])
@@ -124,6 +125,18 @@ class SSDPServer(DatagramProtocol):
                       response)
     self.transport.write(response, address)
 
+  def GetHostAddress(self, address):
+    """Get host address used when communicating with given udp address.
+
+    Args:
+      address: A tuple of destination IP (string) and port (int)
+
+    Returns:
+      A tuple of host IP (string) and port (int)
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(address)
+    return s.getsockname()
 
 def StartSSDPServer():
   """Start an SSDP server.

--- a/ssdp.py
+++ b/ssdp.py
@@ -42,7 +42,12 @@ class SSDPServer(DatagramProtocol):
       else:
         self.logger.debug('Received SSDP M-SEARCH from %s', address_info)
 
-      self.logger.debug('Received SSDP M-SEARCH on interface %s', self.GetHostAddress(address)[0])
+      host_ip,host_port = self.GetHostAddress(address)
+      self.logger.debug('Received SSDP M-SEARCH on interface %s', host_ip)
+
+      if self.config.has_option('AUTOBACKUP', 'default_interface'):
+        if self.config.get('AUTOBACKUP', 'default_interface') != host_ip:
+          return
 
       if msearch_data.get('discovery_type') == 'MediaServer':
         self.SendSSDPResponse(address)

--- a/ssdp.py
+++ b/ssdp.py
@@ -42,6 +42,8 @@ class SSDPServer(DatagramProtocol):
       else:
         self.logger.debug('Received SSDP M-SEARCH from %s', address_info)
 
+      self.logger.debug('Received SSDP M-SEARCH on interface %s', self.GetHostAddress(address)[0])
+
       if msearch_data.get('discovery_type') == 'MediaServer':
         self.SendSSDPResponse(address)
 


### PR DESCRIPTION
Instead of using the 'default interface' address from .pc_autobackup.cfg, dynamically determine host ip 

 * for mediaserver from ```request.getHost().host```
 * for ssdp server by connecting an udp ```socket.socket``` to the receiver and then using ```s.getsockaddr()```

This is more robust on a machine with a dynamic ip address.